### PR TITLE
Enable rubocop linting using shared github foreman actions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,14 @@
+---
+name: CI
+
+on: pull_request  # yamllint disable-line rule:truthy
+
+concurrency:
+  group: ${{ github.ref_name }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  rubocop:
+    name: Rubocop
+    uses: theforeman/actions/.github/workflows/rubocop.yml@v0
+...


### PR DESCRIPTION
see also https://github.com/theforeman/hammer_cli_foreman_salt/issues/7

I cannot request or assign reviewers. so

@sbernhard @nadjaheitmann
